### PR TITLE
Switch to theme by class name

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,4 @@
-import { withThemeByDataAttribute } from '@storybook/addon-themes';
+import { withThemeByClassName } from '@storybook/addon-themes';
 import type { Preview } from '@storybook/react';
 import '../src/app/globals.css';
 
@@ -11,17 +11,15 @@ const preview: Preview = {
       },
     },
   },
+  decorators: [
+    withThemeByClassName({
+      themes: {
+        light: '',
+        dark: 'dark',
+      },
+      defaultTheme: 'light',
+    }),
+  ]
 };
-
-export const decorators = [
-  withThemeByDataAttribute({
-    themes: {
-      light: 'light',
-      dark: 'dark',
-    },
-    defaultTheme: 'light',
-    attributeName: 'data-mode',
-  }),
-];
 
 export default preview;


### PR DESCRIPTION
Changed the theme decorator from withThemeByDataAttribute to withThemeByClassName to simplify the theme switching mechanism. The new decorator uses class names to switch between light and dark themes, eliminating the need for a custom data attribute.
This will be better aligned with tailwind and HeroUI.