### PR TITLE
Fix GitHub icon spacing

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -15,7 +15,7 @@ export default function Footer() {
                         feedback@66-laps.com
                     </Link>
                 </div>
-                <div className="mx-6">
+                <div className="mx-6 min-w-[32px]">
                     <Link isExternal href="https://github.com/JohnStrunk/66-laps">
                         <Image className="invert h-[32px] w-[32px]" src="/images/github-mark.svg" alt="GitHub" width={32} height={32} />
                     </Link>


### PR DESCRIPTION
Add minimum width to GitHub icon container to prevent it from being squished when the footer is resized.

Fixes #170 