### PR TITLE
Add pinning for devcontainer image digests, adjust PR limits

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,16 @@
   },
   "packageRules": [
     {
+      "description": "Pin devcontainer image digests",
+      "matchManagers": [
+        "devcontainer"
+      ],
+      "matchDepTypes": [
+        "image"
+      ],
+      "pinDigests": true
+    },
+    {
       // Features can be pinned, but they don't support the standard :tag@sha256
       // syntax. It's just one or the other.
       // See: https://github.com/devcontainers/cli/issues/825
@@ -45,12 +55,12 @@
       ]
     }
   ],
-  "prConcurrentLimit": 3,
+  "prConcurrentLimit": 5,
   "prHourlyLimit": 0,
-  "rebaseWhen": "behind-base-branch",
-  "schedule": [
-    "before 9am on Monday"
-  ],
+  "rebaseWhen": "auto",
+  // "schedule": [
+  //   "before 9am on Monday"
+  // ],
   "semanticCommits": "disabled",
   "timezone": "America/New_York"
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to improve dependency management for devcontainer images and optimize pull request automation settings.

**Devcontainer image management:**

* Added a new package rule to pin digests for devcontainer image dependencies, ensuring consistent and reproducible builds.

**Renovate automation settings:**

* Increased the concurrent pull request limit from 3 to 5, allowing more updates to be processed simultaneously.
* Changed `rebaseWhen` from "behind-base-branch" to "auto" for more flexible PR rebasing.
* Commented out the scheduled run configuration, potentially allowing Renovate to run at any time.