### PR TITLE
Increase concurrent PR limit and enable weekly schedule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -55,12 +55,12 @@
       ]
     }
   ],
-  "prConcurrentLimit": 5,
+  "prConcurrentLimit": 15,
   "prHourlyLimit": 0,
   "rebaseWhen": "auto",
-  // "schedule": [
-  //   "before 9am on Monday"
-  // ],
+  "schedule": [
+    "before 9am on Monday"
+  ],
   "semanticCommits": "disabled",
   "timezone": "America/New_York"
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to allow more concurrent pull requests and re-enables a scheduled run time to help manage dependency updates more efficiently.

Renovate configuration changes:

* Increased the `prConcurrentLimit` from 5 to 15, allowing up to 15 pull requests to be open at once for dependency updates.
* Re-enabled the `schedule` setting to run Renovate before 9am on Mondays, ensuring updates are processed at a consistent weekly time.