### PR TITLE
Disable batched testing w/ Mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,7 +1,11 @@
 ---
 # https://docs.mergify.com/
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: default
+    batch_size: 1  # Don't combine PRs into draft multi-merge PRs
     queue_conditions:
       - or:
           - author=JohnStrunk


### PR DESCRIPTION
This pull request makes a small configuration update to the `.github/mergify.yml` file to improve the merge queue behavior. The main change is to limit the number of parallel checks and batch size, ensuring that pull requests are merged individually and sequentially.

* Set `max_parallel_checks` to 1 under `merge_queue` to restrict merges to one at a time.
* Set `batch_size` to 1 in `queue_rules` to prevent combining multiple PRs into draft multi-merge PRs.