### PR TITLE
fix(pool): prevent TypeError during resizing

### DIFF
--- a/src/components/Pool/Pool.tsx
+++ b/src/components/Pool/Pool.tsx
@@ -47,11 +47,15 @@ function PoolContents(props: PoolProps) {
     }, [app, canvasRect]);
 
     useEffect(() => {
+        if (!app.isInitialised) return;
+
         const resizeElement = app.app.resizeTo as HTMLElement;
         if (resizeElement) {
             const observer = new ResizeObserver(() => {
-                // Ensure Pixi knows about the resize and re-calculates its screen size.
-                app.app.resize();
+                // Note: PixiJS v8's Application handles its own resizing automatically when
+                // the `resizeTo` prop is provided. Calling `app.app.resize()` manually here
+                // is redundant and can cause TypeErrors if called during initialization or
+                // destruction (where Pixi specifically nullifies the method).
                 updateCanvasSize();
             });
             observer.observe(resizeElement);


### PR DESCRIPTION
### Summary
This PR fixes a `TypeError: t.app.resize is not a function` in the `Pool` component reported in Sentry.

### Root Cause
The error was caused by a manual `app.app.resize()` call within a `ResizeObserver` firing during asynchronous initialization or after the Pixi Application instance was destroyed. PixiJS specifically nullifies the `resize` method during destruction.

### Changes
- Removed the redundant manual `app.app.resize()` call. PixiJS v8's `Application` handles resizing automatically when the `resizeTo` prop is provided.
- Added an `app.isInitialised` guard to the `useEffect` to ensure the observer logic only runs on an active application instance.

### Verification
- Verified with a reproduction Cucumber scenario that simulated the \"destruction\" state by setting `resize` to `null`.
- Confirmed that the 2D pool still resizes correctly and responsively across viewports using existing E2E tests.
- All 216 automated tests passed.